### PR TITLE
feat: add light mode support

### DIFF
--- a/bio.html
+++ b/bio.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="color-scheme" content="dark light">
   <title>James Dushane | Bio</title>
   <link rel="stylesheet" href="styles.css">
 </head>

--- a/contact.html
+++ b/contact.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="color-scheme" content="dark light">
   <title>James Dushane | Contact</title>
   <link rel="stylesheet" href="styles.css">
 </head>

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="color-scheme" content="dark light">
   <title>James Dushane | Product Strategist</title>
   <link rel="stylesheet" href="styles.css">
 </head>

--- a/styles.css
+++ b/styles.css
@@ -317,3 +317,35 @@ main {
 .project:nth-child(3) {
   animation-delay: 0.2s;
 }
+
+/* Light Mode Overrides */
+@media (prefers-color-scheme: light) {
+  body {
+    background-color: #ffffff;
+    color: var(--black);
+  }
+
+  header {
+    background-color: rgba(255, 255, 255, 0.9);
+  }
+
+  nav a {
+    color: var(--black);
+  }
+
+  .linkedin-icon {
+    filter: invert(1);
+  }
+
+  .hero {
+    background-color: rgba(0, 0, 0, 0.03);
+  }
+
+  .project {
+    background-color: rgba(0, 0, 0, 0.05);
+  }
+
+  .project p {
+    color: var(--gray-dark);
+  }
+}


### PR DESCRIPTION
## Summary
- allow light mode via prefers-color-scheme media query
- advertise dark/light support via color-scheme meta tag


------
https://chatgpt.com/codex/tasks/task_e_6896054a365c83208da38175fa2e25c3